### PR TITLE
Add new feature for multiple Order by

### DIFF
--- a/src/Traits/KTDatatable.php
+++ b/src/Traits/KTDatatable.php
@@ -84,17 +84,7 @@ trait KTDatatable
         /**
          * start:where query
          */
-        if (request('query')) {
-            foreach (request('query') as $field => $value) {
-                if (in_array($field, $validFields)) {
-                    if (is_array(request('query')[$field])) {
-                        $query->whereIn($field, $value);
-                    } else {
-                        $query->where($field, $value);
-                    }
-                }
-            }
-        }
+        $query->filterDatatable();
         /**
          * end:where query
          */
@@ -151,6 +141,11 @@ trait KTDatatable
         if ($sort['field']) {
             return $query->orderBy($sort['field'], $sort['sort']);
         }
+        return $query;
+    }
+
+    public static function scopeFilterDatatable($query)
+    {
         return $query;
     }
 


### PR DESCRIPTION
### The Problems: 
currently, this trait hasn't supported multiple `order by`
### The solutions: 
so I added new code to support (n) `order by clause` declared and it placed at the second `order by clause `argument (and so on), for example:
```
select * from some table 
left join another table
order By field a asc, field b asc, field (n) asc
```

### How to use:
added on the array's arguments Datatable
```
'orders' =>[
                [
                    'field' => 'index',
                    'sort' => 'asc'
                ],
                [
                   field(n)
                ] .....
            ]
```